### PR TITLE
Gilded-Rose-Ruby: Perez

### DIFF
--- a/lib/gilded_rose.rb
+++ b/lib/gilded_rose.rb
@@ -1,16 +1,41 @@
-class GildedRose
-  attr_reader :name, :days_remaining, :quality
+# All items have a days_remaining value which denotes the number of days we have to sell the item
 
-  def initialize(name:, days_remaining:, quality:)
+# All items have a quality value which denotes how valuable the item is
+
+# At the end of each day our system lowers both values for every item
+
+# Once the sell by date has passed, Quality degrades twice as fast
+
+# The Quality of an item is never negative
+
+# "Aged" items actually increases in Quality the older they get
+
+# The Quality of an item is never more than 50, unless "Legendary"
+
+# "Legendary" items never have to be sold or decrease in Quality. They never change.
+
+# "Backstage passes", like "Aged" items, increases in Quality as it's Days Remaining value approaches zero; Quality increases by 2 when there are 10 days or less and by 3 when there are 5 days or less but Quality drops to 0 after the concert
+
+# Our Task
+# We have recently signed a supplier of conjured items. This requires an update to our system:
+# "Conjured" items degrade in Quality twice as fast as normal items
+
+class GildedRose
+  attr_reader :name, :days_remaining, :quality, :attributes
+
+  def initialize(name:, days_remaining:, quality:, attributes:)
     @name = name
     @days_remaining = days_remaining
     @quality = quality
+
+    # an array of distinctions that change how time affects quality
+    @attributes = attributes 
   end
 
   def tick
-    if @name != "Aged Brie" and @name != "Backstage passes to a TAFKAL80ETC concert"
+    if !@attributes.include? 'aged' and @name != "Backstage passes to a TAFKAL80ETC concert"
       if @quality > 0
-        if @name != "Legendary Sulfuras, Hand of Ragnaros"
+        if !@attributes.include? 'legendary'
           @quality = @quality - 1
         end
       end
@@ -31,14 +56,14 @@ class GildedRose
         end
       end
     end
-    if @name != "Legendary Sulfuras, Hand of Ragnaros"
+    if !@attributes.include? 'legendary'
       @days_remaining = @days_remaining - 1
     end
     if @days_remaining < 0
-      if @name != "Aged Brie"
+      if !@attributes.include? 'aged'
         if @name != "Backstage passes to a TAFKAL80ETC concert"
           if @quality > 0
-            if @name != "Legendary Sulfuras, Hand of Ragnaros"
+            if !@attributes.include? 'legendary'
               @quality = @quality - 1
             end
           end

--- a/lib/gilded_rose.rb
+++ b/lib/gilded_rose.rb
@@ -33,7 +33,7 @@ class GildedRose
   end
 
   def tick
-    if !@attributes.include? 'aged' and @name != "Backstage passes to a TAFKAL80ETC concert"
+    if !@attributes.include? 'aged' and !@attributes.include? 'ticket'
       if @quality > 0
         if !@attributes.include? 'legendary'
           @quality = @quality - 1
@@ -42,7 +42,7 @@ class GildedRose
     else
       if @quality < 50
         @quality = @quality + 1
-        if @name == "Backstage passes to a TAFKAL80ETC concert"
+        if @attributes.include? 'ticket'
           if @days_remaining < 11
             if @quality < 50
               @quality = @quality + 1
@@ -61,7 +61,7 @@ class GildedRose
     end
     if @days_remaining < 0
       if !@attributes.include? 'aged'
-        if @name != "Backstage passes to a TAFKAL80ETC concert"
+        if !@attributes.include? 'ticket'
           if @quality > 0
             if !@attributes.include? 'legendary'
               @quality = @quality - 1

--- a/lib/gilded_rose.rb
+++ b/lib/gilded_rose.rb
@@ -29,51 +29,88 @@ class GildedRose
     @quality = quality
 
     # an array of distinctions that change how time affects quality
-    @attributes = attributes 
+    # possible entries = [ 'legendary', 'aged', 'ticket', 'conjured' ]
+    @attributes = attributes.to_set
   end
 
   def tick
-    if !@attributes.include? 'aged' and !@attributes.include? 'ticket'
-      if @quality > 0
-        if !@attributes.include? 'legendary'
-          @quality = @quality - 1
-        end
-      end
-    else
+    puts "Processing item: #{@name}"
+
+    handleStandardItem if @attributes.empty?
+    handleAged if @attributes.include? 'aged'
+    handleLegendary if @attributes.include? 'legendary'
+    handleTicket if @attributes.include? 'ticket'
+    handleConjured if @attributes.include? 'conjured'
+
+    puts "Item processed: #{self.inspect}"
+  end
+
+  private
+
+  def handleStandardItem
+    handleStandardDegredation
+  end
+
+  def handleAged
+    # aged items cannot exceed quality of 50
+    if @quality < 50
+      @quality = @quality + 1
+    end
+
+    @days_remaining = @days_remaining - 1
+    if @days_remaining < 0
       if @quality < 50
         @quality = @quality + 1
-        if @attributes.include? 'ticket'
-          if @days_remaining < 11
-            if @quality < 50
-              @quality = @quality + 1
-            end
-          end
-          if @days_remaining < 6
-            if @quality < 50
-              @quality = @quality + 1
-            end
-          end
-        end
       end
     end
-    if !@attributes.include? 'legendary'
-      @days_remaining = @days_remaining - 1
-    end
-    if @days_remaining < 0
-      if !@attributes.include? 'aged'
-        if !@attributes.include? 'ticket'
-          if @quality > 0
-            if !@attributes.include? 'legendary'
-              @quality = @quality - 1
-            end
-          end
-        else
-          @quality = @quality - @quality
-        end
-      else
+  end
+
+  def handleLegendary
+    # No Op - legendary items remain unchanged
+  end
+
+  def handleTicket
+    if @quality < 50
+      @quality = @quality + 1
+
+      if @days_remaining < 11
         if @quality < 50
           @quality = @quality + 1
         end
+      end
+      
+      if @days_remaining < 6
+        if @quality < 50
+          @quality = @quality + 1
+        end
+      end
+    end
+
+    @days_remaining = @days_remaining - 1
+
+    if @days_remaining < 0
+      @quality = 0
+      return
+    end
+  end
+
+  # Identical behavior to standard item with exeption of degradation rate
+  # Utilizes abstracted 'handleStandardDegradation' method
+  def handleConjured
+    handleStandardDegredation(2)
+  end
+
+  # handles standard degrading item behavior
+  # takes param 'decrementValue' to affect rate of degradation
+  def handleStandardDegredation(decrementValue = 1)
+    if @quality > 0
+      @quality = @quality - decrementValue
+    end
+
+    @days_remaining = @days_remaining - 1
+    if @days_remaining < 0
+      if @quality > 0
+        @quality = @quality - decrementValue
       end
     end
   end

--- a/spec/gilded_rose_spec.rb
+++ b/spec/gilded_rose_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe GildedRose do
 
   context "Backstage Pass" do
     it "long before sell date" do
-      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: 11, quality: 10, attributes: [])
+      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: 11, quality: 10, attributes: ['ticket'])
 
       gilded_rose.tick
 
@@ -133,7 +133,7 @@ RSpec.describe GildedRose do
     end
 
     it "long before sell date at max quality" do
-      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: 11, quality: 50, attributes: [])
+      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: 11, quality: 50, attributes: ['ticket'])
 
       gilded_rose.tick
 
@@ -141,7 +141,7 @@ RSpec.describe GildedRose do
     end
 
     it "medium close to sell date upper bound" do
-      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: 10, quality: 10, attributes: [])
+      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: 10, quality: 10, attributes: ['ticket'])
 
       gilded_rose.tick
 
@@ -149,7 +149,7 @@ RSpec.describe GildedRose do
     end
 
     it "medium close to sell date upper bound at max quality" do
-      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: 10, quality: 50, attributes: [])
+      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: 10, quality: 50, attributes: ['ticket'])
 
       gilded_rose.tick
 
@@ -157,7 +157,7 @@ RSpec.describe GildedRose do
     end
 
     it "medium close to sell date lower bound" do
-      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: 6, quality: 10, attributes: [])
+      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: 6, quality: 10, attributes: ['ticket'])
 
       gilded_rose.tick
 
@@ -165,7 +165,7 @@ RSpec.describe GildedRose do
     end
 
     it "medium close to sell date lower bound at max quality" do
-      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: 6, quality: 50, attributes: [])
+      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: 6, quality: 50, attributes: ['ticket'])
 
       gilded_rose.tick
 
@@ -173,7 +173,7 @@ RSpec.describe GildedRose do
     end
 
     it "very close to sell date upper bound" do
-      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: 5, quality: 10, attributes: [])
+      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: 5, quality: 10, attributes: ['ticket'])
 
       gilded_rose.tick
 
@@ -181,7 +181,7 @@ RSpec.describe GildedRose do
     end
 
     it "very close to sell date upper bound at max quality" do
-      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: 5, quality: 50, attributes: [])
+      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: 5, quality: 50, attributes: ['ticket'])
 
       gilded_rose.tick
 
@@ -189,7 +189,7 @@ RSpec.describe GildedRose do
     end
 
     it "very close to sell date lower bound" do
-      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: 1, quality: 10, attributes: [])
+      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: 1, quality: 10, attributes: ['ticket'])
 
       gilded_rose.tick
 
@@ -197,7 +197,7 @@ RSpec.describe GildedRose do
     end
 
     it "very close to sell date lower bound at max quality" do
-      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: 1, quality: 50, attributes: [])
+      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: 1, quality: 50, attributes: ['ticket'])
 
       gilded_rose.tick
 
@@ -205,7 +205,7 @@ RSpec.describe GildedRose do
     end
 
     it "on sell date" do
-      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: 0, quality: 10, attributes: [])
+      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: 0, quality: 10, attributes: ['ticket'])
 
       gilded_rose.tick
 
@@ -213,7 +213,7 @@ RSpec.describe GildedRose do
     end
 
     it "after sell date" do
-      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: -10, quality: 10, attributes: [])
+      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: -10, quality: 10, attributes: ['ticket'])
 
       gilded_rose.tick
 

--- a/spec/gilded_rose_spec.rb
+++ b/spec/gilded_rose_spec.rb
@@ -2,10 +2,12 @@ require "spec_helper"
 
 require_relative "../lib/gilded_rose"
 
+# possible attributes for items: [ 'aged', 'legendary', 'conjured' ]
+
 RSpec.describe GildedRose do
   context "Normal Item" do
     it "before sell date" do
-      gilded_rose = GildedRose.new(name: "Normal Item", days_remaining: 5, quality: 10)
+      gilded_rose = GildedRose.new(name: "Normal Item", days_remaining: 5, quality: 10, attributes: [])
 
       gilded_rose.tick
 
@@ -13,7 +15,7 @@ RSpec.describe GildedRose do
     end
 
     it "on sell date" do
-      gilded_rose = GildedRose.new(name: "Normal Item", days_remaining: 0, quality: 10)
+      gilded_rose = GildedRose.new(name: "Normal Item", days_remaining: 0, quality: 10, attributes: [])
 
       gilded_rose.tick
 
@@ -21,7 +23,7 @@ RSpec.describe GildedRose do
     end
 
     it "after sell date" do
-      gilded_rose = GildedRose.new(name: "Normal Item", days_remaining: -10, quality: 10)
+      gilded_rose = GildedRose.new(name: "Normal Item", days_remaining: -10, quality: 10, attributes: [])
 
       gilded_rose.tick
 
@@ -29,7 +31,7 @@ RSpec.describe GildedRose do
     end
 
     it "of zero quality" do
-      gilded_rose = GildedRose.new(name: "Normal Item", days_remaining: 5, quality: 0)
+      gilded_rose = GildedRose.new(name: "Normal Item", days_remaining: 5, quality: 0, attributes: [])
 
       gilded_rose.tick
 
@@ -39,7 +41,7 @@ RSpec.describe GildedRose do
 
   context "Aged Brie" do
     it "before sell date" do
-      gilded_rose = GildedRose.new(name: "Aged Brie", days_remaining: 5, quality: 10)
+      gilded_rose = GildedRose.new(name: "Aged Brie", days_remaining: 5, quality: 10, attributes: ['aged'])
 
       gilded_rose.tick
 
@@ -47,7 +49,7 @@ RSpec.describe GildedRose do
     end
 
     it "with max quality" do
-      gilded_rose = GildedRose.new(name: "Aged Brie", days_remaining: 5, quality: 50)
+      gilded_rose = GildedRose.new(name: "Aged Brie", days_remaining: 5, quality: 50, attributes: ['aged'])
 
       gilded_rose.tick
 
@@ -55,7 +57,7 @@ RSpec.describe GildedRose do
     end
 
     it "on sell date" do
-      gilded_rose = GildedRose.new(name: "Aged Brie", days_remaining: 0, quality: 10)
+      gilded_rose = GildedRose.new(name: "Aged Brie", days_remaining: 0, quality: 10, attributes: ['aged'])
 
       gilded_rose.tick
 
@@ -63,7 +65,7 @@ RSpec.describe GildedRose do
     end
 
     it "on sell date near max quality" do
-      gilded_rose = GildedRose.new(name: "Aged Brie", days_remaining: 0, quality: 49)
+      gilded_rose = GildedRose.new(name: "Aged Brie", days_remaining: 0, quality: 49, attributes: ['aged'])
 
       gilded_rose.tick
 
@@ -71,7 +73,7 @@ RSpec.describe GildedRose do
     end
 
     it "on sell date with max quality" do
-      gilded_rose = GildedRose.new(name: "Aged Brie", days_remaining: 0, quality: 50)
+      gilded_rose = GildedRose.new(name: "Aged Brie", days_remaining: 0, quality: 50, attributes: ['aged'])
 
       gilded_rose.tick
 
@@ -79,7 +81,7 @@ RSpec.describe GildedRose do
     end
 
     it "after sell date" do
-      gilded_rose = GildedRose.new(name: "Aged Brie", days_remaining: -10, quality: 10)
+      gilded_rose = GildedRose.new(name: "Aged Brie", days_remaining: -10, quality: 10, attributes: ['aged'])
 
       gilded_rose.tick
 
@@ -87,7 +89,7 @@ RSpec.describe GildedRose do
     end
 
     it "after sell date with max quality" do
-      gilded_rose = GildedRose.new(name: "Aged Brie", days_remaining: -10, quality: 50)
+      gilded_rose = GildedRose.new(name: "Aged Brie", days_remaining: -10, quality: 50, attributes: ['aged'])
 
       gilded_rose.tick
 
@@ -97,7 +99,7 @@ RSpec.describe GildedRose do
 
   context "Sulfuras" do
     it "before sell date" do
-      gilded_rose = GildedRose.new(name: "Legendary Sulfuras, Hand of Ragnaros", days_remaining: 5, quality: 80)
+      gilded_rose = GildedRose.new(name: "Legendary Sulfuras, Hand of Ragnaros", days_remaining: 5, quality: 80, attributes: ['legendary'])
 
       gilded_rose.tick
 
@@ -105,7 +107,7 @@ RSpec.describe GildedRose do
     end
 
     it "on sell date" do
-      gilded_rose = GildedRose.new(name: "Legendary Sulfuras, Hand of Ragnaros", days_remaining: 0, quality: 80)
+      gilded_rose = GildedRose.new(name: "Legendary Sulfuras, Hand of Ragnaros", days_remaining: 0, quality: 80, attributes: ['legendary'])
 
       gilded_rose.tick
 
@@ -113,7 +115,7 @@ RSpec.describe GildedRose do
     end
 
     it "after sell date" do
-      gilded_rose = GildedRose.new(name: "Legendary Sulfuras, Hand of Ragnaros", days_remaining: -10, quality: 80)
+      gilded_rose = GildedRose.new(name: "Legendary Sulfuras, Hand of Ragnaros", days_remaining: -10, quality: 80, attributes: ['legendary'])
 
       gilded_rose.tick
 
@@ -123,7 +125,7 @@ RSpec.describe GildedRose do
 
   context "Backstage Pass" do
     it "long before sell date" do
-      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: 11, quality: 10)
+      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: 11, quality: 10, attributes: [])
 
       gilded_rose.tick
 
@@ -131,7 +133,7 @@ RSpec.describe GildedRose do
     end
 
     it "long before sell date at max quality" do
-      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: 11, quality: 50)
+      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: 11, quality: 50, attributes: [])
 
       gilded_rose.tick
 
@@ -139,7 +141,7 @@ RSpec.describe GildedRose do
     end
 
     it "medium close to sell date upper bound" do
-      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: 10, quality: 10)
+      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: 10, quality: 10, attributes: [])
 
       gilded_rose.tick
 
@@ -147,7 +149,7 @@ RSpec.describe GildedRose do
     end
 
     it "medium close to sell date upper bound at max quality" do
-      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: 10, quality: 50)
+      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: 10, quality: 50, attributes: [])
 
       gilded_rose.tick
 
@@ -155,7 +157,7 @@ RSpec.describe GildedRose do
     end
 
     it "medium close to sell date lower bound" do
-      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: 6, quality: 10)
+      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: 6, quality: 10, attributes: [])
 
       gilded_rose.tick
 
@@ -163,7 +165,7 @@ RSpec.describe GildedRose do
     end
 
     it "medium close to sell date lower bound at max quality" do
-      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: 6, quality: 50)
+      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: 6, quality: 50, attributes: [])
 
       gilded_rose.tick
 
@@ -171,7 +173,7 @@ RSpec.describe GildedRose do
     end
 
     it "very close to sell date upper bound" do
-      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: 5, quality: 10)
+      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: 5, quality: 10, attributes: [])
 
       gilded_rose.tick
 
@@ -179,7 +181,7 @@ RSpec.describe GildedRose do
     end
 
     it "very close to sell date upper bound at max quality" do
-      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: 5, quality: 50)
+      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: 5, quality: 50, attributes: [])
 
       gilded_rose.tick
 
@@ -187,7 +189,7 @@ RSpec.describe GildedRose do
     end
 
     it "very close to sell date lower bound" do
-      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: 1, quality: 10)
+      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: 1, quality: 10, attributes: [])
 
       gilded_rose.tick
 
@@ -195,7 +197,7 @@ RSpec.describe GildedRose do
     end
 
     it "very close to sell date lower bound at max quality" do
-      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: 1, quality: 50)
+      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: 1, quality: 50, attributes: [])
 
       gilded_rose.tick
 
@@ -203,7 +205,7 @@ RSpec.describe GildedRose do
     end
 
     it "on sell date" do
-      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: 0, quality: 10)
+      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: 0, quality: 10, attributes: [])
 
       gilded_rose.tick
 
@@ -211,7 +213,7 @@ RSpec.describe GildedRose do
     end
 
     it "after sell date" do
-      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: -10, quality: 10)
+      gilded_rose = GildedRose.new(name: "Backstage passes to a TAFKAL80ETC concert", days_remaining: -10, quality: 10, attributes: [])
 
       gilded_rose.tick
 
@@ -220,48 +222,48 @@ RSpec.describe GildedRose do
   end
 
   context "Conjured Mana" do
-    xit "before sell date" do
-      gilded_rose = GildedRose.new(name: "Conjured Mana Cake", days_remaining: 5, quality: 10)
+    it "before sell date" do
+      gilded_rose = GildedRose.new(name: "Conjured Mana Cake", days_remaining: 5, quality: 10, attributes: ['conjured'])
 
       gilded_rose.tick
 
       expect(gilded_rose).to have_attributes(days_remaining: 4, quality: 8)
     end
 
-    xit "before sell date at zero quality" do
-      gilded_rose = GildedRose.new(name: "Conjured Mana Cake", days_remaining: 5, quality: 0)
+    it "before sell date at zero quality" do
+      gilded_rose = GildedRose.new(name: "Conjured Mana Cake", days_remaining: 5, quality: 0, attributes: ['conjured'])
 
       gilded_rose.tick
 
       expect(gilded_rose).to have_attributes(days_remaining: 4, quality: 0)
     end
 
-    xit "on sell date" do
-      gilded_rose = GildedRose.new(name: "Conjured Mana Cake", days_remaining: 0, quality: 10)
+    it "on sell date" do
+      gilded_rose = GildedRose.new(name: "Conjured Mana Cake", days_remaining: 0, quality: 10, attributes: ['conjured'])
 
       gilded_rose.tick
 
       expect(gilded_rose).to have_attributes(days_remaining: -1, quality: 6)
     end
 
-    xit "on sell date at zero quality" do
-      gilded_rose = GildedRose.new(name: "Conjured Mana Cake", days_remaining: 0, quality: 0)
+    it "on sell date at zero quality" do
+      gilded_rose = GildedRose.new(name: "Conjured Mana Cake", days_remaining: 0, quality: 0, attributes: ['conjured'])
 
       gilded_rose.tick
 
       expect(gilded_rose).to have_attributes(days_remaining: -1, quality: 0)
     end
 
-    xit "after sell date" do
-      gilded_rose = GildedRose.new(name: "Conjured Mana Cake", days_remaining: -10, quality: 10)
+    it "after sell date" do
+      gilded_rose = GildedRose.new(name: "Conjured Mana Cake", days_remaining: -10, quality: 10, attributes: ['conjured'])
 
       gilded_rose.tick
 
       expect(gilded_rose).to have_attributes(days_remaining: -11, quality: 6)
     end
 
-    xit "after sell date at zero quality" do
-      gilded_rose = GildedRose.new(name: "Conjured Mana Cake", days_remaining: -10, quality: 0)
+    it "after sell date at zero quality" do
+      gilded_rose = GildedRose.new(name: "Conjured Mana Cake", days_remaining: -10, quality: 0, attributes: ['conjured'])
 
       gilded_rose.tick
 


### PR DESCRIPTION
## **Gilded Rose Kata in Ruby**

The world-renown Gilded Rose is in desperate need of some internal renovations! Fortunately I have experience with renovation projects such as this. 

Requirements were as follows: 
- All items have a days_remaining value which denotes the number of days we have to sell the item
- All items have a quality value which denotes how valuable the item is
- At the end of each day our system lowers both values for every item
- Once the sell by date has passed, Quality degrades twice as fast
- The Quality of an item is never negative
- "Aged" items actually increases in Quality the older they get
- The Quality of an item is never more than 50, unless "Legendary"
- "Legendary" items never have to be sold or decrease in Quality. They never change.
- "Backstage passes", like "Aged" items, increases in Quality as it's Days Remaining value approaches zero; Quality increases by 2 when there are 10 days or less and by 3 when there are 5 days or less but Quality drops to 0 after the concert

The change requirement:
- "Conjured" items degrade in Quality twice as fast as normal items

## The approach to the solution:
- After carefully reviewing the requirements and turning to the implementation, the first big issue was how items were referenced by the `name` attribute. Obviously this is not scalable in any scenario once more new items need to be added, so I made the decision to extend the `item` data object with an array of `attributes`. (Line 33 of `gilded_rose.rb`)
That takes care of the issue of explicit name reference and allows for a much faster addition of other item `types`. 
*Note:  I worked under the assumption that items will only have a single attribute, but having `item.attributes` as an array allows for quickly adding many attributes in the future. Coupled with the improvements to the `tick` method, it would then be significantly easier to handle an item with many attributes going forward.*
- After updating the `tick` method to check items based on the new `attributes` field of an `item`, I needed to update all specs to utilize this new schema as well.

**The tick method**
- Given the cognitive complexity of the entire function, I decided the optimal course would be for each item type to get it's own handler function. With items now grouped by attribute, it was easy enough to add conditional checks. 
- In order to break down what parts of the method were responsible for each item `attribute`, I isolated the tests required to pass for a given item type and broke out the logic from `tick` into a specific handler:
```handleAged if @attributes.include? 'aged' # line 40 ```
- I added a bit of 'logging' of the item and it's updated state to more easily track it during the refactor.
- From there, it was a tedious-but-straightforward task to refactor.
- And finally, adding the new requirement was a perfect test to see how much easier it would be to add a new item type with it's own logic! Took just minutes to uncomment the `conjured` tests and add the new handler for that type.
- Once all requirements were met, I took a couple of opportunities to DRY up very common item logic paths (standard item vs. conjured item is identical except for the quality degradation rate). 

Now, it should be trivial to add new items to existing item 'types', and much more straight-forward to add new handlers for any new types. Hooray for the Gilded Rose!
